### PR TITLE
Allow `FlutterListViewElement.notifyStickyChanged` to fail

### DIFF
--- a/lib/src/flutter_list_view_element.dart
+++ b/lib/src/flutter_list_view_element.dart
@@ -198,7 +198,7 @@ class FlutterListViewElement extends RenderObjectElement {
       _isInScrolling = true;
       var position = parentScrollableState?.position;
 
-      if(position != null && position.maxScrollExtent < scrollOffset) {
+      if (position != null && position.maxScrollExtent < scrollOffset) {
         scrollOffset = position.maxScrollExtent;
       }
 
@@ -254,7 +254,12 @@ class FlutterListViewElement extends RenderObjectElement {
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       if (widget.controller != null) {
         if (widget.controller!.stickyIndex.value != index) {
-          widget.controller!.stickyIndex.value = index;
+          try {
+            widget.controller!.stickyIndex.value = index;
+          } catch (e) {
+            // [ValueNotifier] may be disposed at this moment, so it's allowed
+            // to fail.
+          }
         }
       }
     });


### PR DESCRIPTION
The method sometimes seems to throw `ValueNotifier was used after being disposed`, so this PR adds `try/catch` to guard that.